### PR TITLE
設定構造体の作成

### DIFF
--- a/classes.json
+++ b/classes.json
@@ -1,1 +1,1 @@
-{"ClassData":null,"SumId":0,"TimeMargin":1}
+{"ClassData":[{"Id":1,"Name":"のぎ","Weekday":"Sunday","Date":"","Start":"12:00","End":"23:00","Url":"https://www.nogizaka46.com"},{"Id":2,"Name":"けやき","Weekday":"Monday","Date":"","Start":"12:00","End":"23:00","Url":"https://www.keyakizaka46.com"},{"Id":3,"Name":"ひなた","Weekday":"Tuesday","Date":"","Start":"12:00","End":"23:00","Url":"https://www.hinatazaka46.com"},{"Id":4,"Name":"さくら","Weekday":"Wednesday","Date":"","Start":"12:00","End":"23:00","Url":"https://www.sakurazaka46.com"}],"SumId":4,"TimeMargin":10}

--- a/startzoom.go
+++ b/startzoom.go
@@ -307,13 +307,14 @@ func editDeleteClasses(classes []ClassData) (editedClasses []ClassData) {
 	}
 	return
 }
-/**/
+/*開始前の時間の余裕を設定する関数*/
 func editTimeMargin(config Config) (timeMargin int) {
 	fmt.Println("Zoom開始時刻の何分前から起動するようにするか設定します(現在は", config.TimeMargin, "分)")
 	return InputNum("何分前から起動可能に設定しますか？")
 }
 /*設定変更を行う関数*/
 func editConfig(config Config) (editedConfig Config) {
+	editedConfig = config
 	fmt.Println("設定の変更をします")
 	switch InputNum("0: 戻る, 1: Zoom開始前の余裕時間") {
 	case 1: editedConfig.TimeMargin = editTimeMargin(config)


### PR DESCRIPTION
## Related Issue
#11 
## What
- Zoomデータと設定用フィールドを格納できる構造体を作成
- 新たな構造体構造に対応するよう各関数を修正
- Zoom開始前の余裕を変更可能に、それに合わせその値を設定する機能を追加
- 各Zoomデータに`id`を付加できるよう変更

## Memo
<!-- その他コメント -->
`saveConfig`でファイルが存在しないときに出るエラーも修正した