### PR TITLE
コマンドラインオプションを設定

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,9 @@
 package main
 
+import "flag"
+
 func main() {
-	StartZoomMain()
+	flag.Parse()
+	args := flag.Args()
+	StartZoomMain(args)
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,19 @@
 package main
 
-import "flag"
+import (
+	"github.com/jessevdk/go-flags"
+	"os"
+)
+
+type Options struct {
+	Start []bool `short:"s" long:"start" description:"Get starting zoom"`
+}
+var opts Options
 
 func main() {
-	flag.Parse()
-	args := flag.Args()
-	StartZoomMain(args)
+	_, err := flags.Parse(&opts)
+	if err != nil {
+		os.Exit(1)
+	}
+	StartZoomMain(opts)
 }

--- a/startzoom.go
+++ b/startzoom.go
@@ -30,7 +30,7 @@ type ClassData struct {
 
 var sc = bufio.NewScanner(os.Stdin)
 
-/*intのスライスにある値が含まれているか調べる関数*/
+/*スライスにある値が含まれているか調べる関数*/
 func contains (s []string, value string) bool {
 	for _, v := range s {
 		if value == v {
@@ -360,7 +360,12 @@ func editConfig(config Config) (editedConfig Config) {
 func StartZoomMain(args []string) {
 	filename := "classes.json"
 	config := loadClasses(filename)
-	
+
+	if contains(args, "start") {
+		startZoom(config.ClassData, config.TimeMargin)
+		return
+	}
+
 	fmt.Println("\n" +
 		"---------------------------------------------\n" +
 		"----------------- StartZoom -----------------\n" +

--- a/startzoom.go
+++ b/startzoom.go
@@ -168,7 +168,12 @@ func checkTime(trueNow time.Time, cd ClassData, timeMargin int) bool {
 /*曜日か日付が合致するZoomを探す関数*/
 func startZoom(classes []ClassData, timeMargin int) {
 	trueNow := time.Now()
-	fmt.Println("現在時刻:", trueNow.Hour(), ":", trueNow.Minute())
+	hour := strconv.Itoa(trueNow.Hour())
+	min := strconv.Itoa(trueNow.Minute())
+	if trueNow.Minute() < 10 {
+		min = "0" + min
+	}
+	fmt.Println("現在時刻:", hour, ":", min)
 	_, month, day := trueNow.Date()
 	today := strconv.Itoa(int(month)) + "-" + strconv.Itoa(day)
 	for _, cd := range classes {

--- a/startzoom.go
+++ b/startzoom.go
@@ -30,15 +30,6 @@ type ClassData struct {
 
 var sc = bufio.NewScanner(os.Stdin)
 
-/*スライスにある値が含まれているか調べる関数*/
-func contains (s []string, value string) bool {
-	for _, v := range s {
-		if value == v {
-			return true
-		}
-	}
-	return false
-}
 /*入力読み込み用関数*/
 func read() string {
 	sc.Scan()
@@ -357,11 +348,11 @@ func editConfig(config Config) (editedConfig Config) {
 	return
 }
 /*メイン関数*/
-func StartZoomMain(args []string) {
+func StartZoomMain(opts Options) {
 	filename := "classes.json"
 	config := loadClasses(filename)
 
-	if contains(args, "start") {
+	if len(opts.Start) != 0 {
 		startZoom(config.ClassData, config.TimeMargin)
 		return
 	}

--- a/startzoom.go
+++ b/startzoom.go
@@ -30,6 +30,15 @@ type ClassData struct {
 
 var sc = bufio.NewScanner(os.Stdin)
 
+/*intのスライスにある値が含まれているか調べる関数*/
+func contains (s []string, value string) bool {
+	for _, v := range s {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}
 /*入力読み込み用関数*/
 func read() string {
 	sc.Scan()
@@ -159,7 +168,6 @@ func checkTime(trueNow time.Time, cd ClassData, timeMargin int) bool {
 	now, _ := time.Parse("15:04", strconv.Itoa(trueNow.Hour())+ ":" +strconv.Itoa(trueNow.Minute()))
 	startTime, _ := time.Parse("15:04", cd.Start)
 	startTime = startTime.Add(time.Duration(-1 * timeMargin) * time.Minute)
-	fmt.Println("startTime: ", startTime)
 	endTime, _ := time.Parse("15:04", cd.End)
 	if startTime.Before(now) && endTime.After(now) {
 		return true
@@ -349,10 +357,10 @@ func editConfig(config Config) (editedConfig Config) {
 	return
 }
 /*メイン関数*/
-func StartZoomMain() {
+func StartZoomMain(args []string) {
 	filename := "classes.json"
 	config := loadClasses(filename)
-
+	
 	fmt.Println("\n" +
 		"---------------------------------------------\n" +
 		"----------------- StartZoom -----------------\n" +


### PR DESCRIPTION
## Related Issue
#10 
## What
- `go-flags`というオプションを扱えるパッケージを導入
- `-s` `start` コマンドでその時間に合ったZoomを開始できる機能を追加
- `-h`コマンドでヘルプを見られるようにした
- `startZoom`関数の時刻表示を自然なものへと修正

## Memo
<!-- その他コメント -->
`-s`がオプションとして入力された場合`opts.Start`スライスにその数だけ`true`が入るが、されなければ空スライスになるため、`-s`が指定されたかどうかの判定をスライスの長さが0か否かで判定している。
この実装が正しいか不明なので一応メモ