### PR TITLE
該当する開始時刻のZoomがないとき最も近いZoomを起動する機能の追加

### DIFF
--- a/startzoom.go
+++ b/startzoom.go
@@ -361,12 +361,23 @@ func editTimeMargin(config Config) (timeMargin int) {
 	fmt.Println("\nZoom開始時刻の何分前から起動するようにするか設定します(現在は", config.TimeMargin, "分)")
 	return InputNum("何分前から起動可能に設定しますか？")
 }
+/*該当Zoomがないときに近いZoomを開くかどうかを設定する関数*/
+func editIsAsk(config Config) bool {
+	fmt.Println("授業開始を選択した際に、開始時刻に該当するZoomがなかったときに、同じ日のなかで" +
+					"最も開始時刻の近いZoomを開くかどうかの質問の有無を設定します")
+	if InputNum("1: 聞く, 2: 聞かない") == 1 {
+		return true
+	} else {
+		return false
+	}
+}
 /*設定変更を行う関数*/
 func editConfig(config Config) (editedConfig Config) {
 	editedConfig = config
 	fmt.Println("\n設定の変更をします")
-	switch InputNum("0: 戻る, 1: Zoom開始前の余裕時間, 2: ") {
+	switch InputNum("0: 戻る, 1: Zoom開始前の余裕時間, 2: 該当Zoomがない場合の質問") {
 	case 1: editedConfig.TimeMargin = editTimeMargin(config)
+	case 2: editedConfig.IsAsk = editIsAsk(config)
 	default: return config
 	}
 	fmt.Println("設定を変更しました")

--- a/startzoom.go
+++ b/startzoom.go
@@ -204,6 +204,7 @@ func startZoom(config Config, timeMargin int) {
 		msg := nearClass.Start + " から " + nearClass.Name + " が始まりますが、起動しますか？" +
 			"\n1: はい, 2: いいえ"
 		if InputNum(msg) == 1 {
+			runZoom(nearClass)
 		} else {
 			fmt.Println("起動せず戻ります")
 		}

--- a/startzoom.go
+++ b/startzoom.go
@@ -171,6 +171,15 @@ func checkTime(trueNow time.Time, cd ClassData, timeMargin int) bool {
 	}
 	return false
 }
+/*早い方のZoomデータを返す関数*/
+func earlyClass(data1 ClassData, data2 ClassData) ClassData {
+	time1, _ := time.Parse("15:04", data1.Start)
+	time2, _ := time.Parse("15:04", data2.Start)
+	if time1.Before(time2) {
+		return data1
+	}
+	return data2
+}
 /*曜日か日付が合致するZoomを探す関数*/
 func startZoom(config Config, timeMargin int) {
 	classes := config.Classes
@@ -185,17 +194,21 @@ func startZoom(config Config, timeMargin int) {
 	_, month, day := trueNow.Date()
 	today := strconv.Itoa(int(month)) + "-" + strconv.Itoa(day)
 	for _, cd := range classes {
-		if cd.Date == today && checkTime(trueNow, cd, timeMargin) {
-			nearClass = cd
-			runZoom(cd)
-			return
+		if cd.Date == today {
+			if checkTime(trueNow, cd, timeMargin) {
+				runZoom(cd)
+				return
+			}
+			nearClass = earlyClass(nearClass, cd)
 		}
 	}
 	for _, cd := range classes {
-		if cd.Weekday == trueNow.Weekday().String() && checkTime(trueNow, cd, timeMargin) {
-			nearClass = cd
-			runZoom(cd)
-			return
+		if cd.Weekday == trueNow.Weekday().String() {
+			if checkTime(trueNow, cd, timeMargin) {
+				runZoom(cd)
+				return
+			}
+			nearClass = earlyClass(nearClass, cd)
 		}
 	}
 	fmt.Println("現在または", timeMargin, "分後に進行中の授業はありません")

--- a/startzoom.go
+++ b/startzoom.go
@@ -199,7 +199,11 @@ func startZoom(config Config, timeMargin int) {
 				runZoom(cd)
 				return
 			}
-			nearClass = earlyClass(nearClass, cd)
+			if nearClass.Name != "" {
+				nearClass = earlyClass(nearClass, cd)
+			} else {
+				nearClass = cd
+			}
 		}
 	}
 	for _, cd := range classes {
@@ -208,7 +212,11 @@ func startZoom(config Config, timeMargin int) {
 				runZoom(cd)
 				return
 			}
-			nearClass = earlyClass(nearClass, cd)
+			if nearClass.Name != "" {
+				nearClass = earlyClass(nearClass, cd)
+			} else {
+				nearClass = cd
+			}
 		}
 	}
 	fmt.Println("現在または", timeMargin, "分後に進行中の授業はありません")

--- a/startzoom.go
+++ b/startzoom.go
@@ -16,6 +16,7 @@ type Config struct {
 	ClassData 	[]ClassData `json:"ClassData"`
 	SumId 		int `json:"SumId"`
 	TimeMargin	int `json:"TimeMargin"`
+	IsAsk		bool `json:"IsAsk"`
 }
 /*授業の情報を格納する構造体*/
 type ClassData struct {
@@ -57,7 +58,9 @@ func loadClasses(filename string) (config Config) {
 		if _, err := os.Create(filename); err != nil {
 			log.Fatal(err)
 		}
+		config.SumId = 0
 		config.TimeMargin = 10
+		config.IsAsk = false
 	}
 	bytes, err := ioutil.ReadFile(filename)	//json読み込み
 	if err != nil {


### PR DESCRIPTION
## Related Issue
#21 
## What
- 起動するZoomがないとき、最も近い開始時刻のZoomを起動するか提案するよう変更
- 最も近い開始時刻のZoomを探す処理を追加
- 最も近い開始時刻のZoomを起動できる機能を追加
- 設定で提案のオンオフ切り替えできるよう変更

## Memo
<!-- その他コメント -->
